### PR TITLE
[Setting/#12] 브랜치 별 배포 workflow 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/amp-server
     steps:
       # 1. 레포 체크아웃
       - name: Checkout
@@ -48,19 +46,17 @@ jobs:
       # 도커 이미지 빌드
       - name: Build Docker image
         run: |
-          docker build -t $IMAGE_NAME:${{ steps.tag.outputs.tag }} .
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/amp-server:${{ steps.tag.outputs.tag }} .
 
       # 도커 이미지 푸시
       - name: Push Docker image
         run: |
-          docker push $IMAGE_NAME:${{ steps.tag.outputs.tag }}
+          docker push ${{ secrets.DOCKER_USERNAME }}/amp-server:${{ steps.tag.outputs.tag }}
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
-    env:
-      IMAGE_NAME: ${{ secrets.DOCKER_USERNAME }}/amp-server
 
     steps:
       # Ec2에 배포
@@ -71,7 +67,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_KEY }}
           script: |
-            IMAGE=$IMAGE_NAME:latest
+            IMAGE=${{ secrets.DOCKER_USERNAME }}/amp-server:latest
           
             echo "📦 Docker image pull 시도"
           


### PR DESCRIPTION
## 💭 Related Issue
closed #12 

<br/>

## 💻 Key Changes
- main/develop 브랜치 별 배포 workflow 분리로직 적용

<br/>

## 💪🏻 To Reviewers
- 이전 인프라 세팅에서 정상적으로 도커 컨테이너, ec2 실행, rds 연결 성공 모두 확인해서 develop 브랜치와 main브랜치에서 deploy workflow 분리했습니다.
- develop 브랜치에서는 빌드 ~ 도커 허브에 이미지 푸시까지, main브랜치에서는 빌드 ~ ec2 실행까지 진행되도록 적용했습니다.

<br/>

## 📎 ETC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 빌드 작업명이 변경되고, 브랜치에 따라 Docker 태그를 동적으로 생성(메인: latest, 개발: 브랜치명 기반).
  * 이미지 빌드·푸시가 계산된 태그를 사용하도록 업데이트.
  * 메인 전용 배포 작업 추가(빌드에 의존) 및 배포 스크립트 강화:
    * 이미지 존재 확인, docker pull 재시도(지연 포함), 기존 컨테이너 중지·제거 후 새 컨테이너로 교체.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->