### PR TITLE
[Refactor/#26] 에러 응답 형식 수정

### DIFF
--- a/src/main/java/com/amp/global/common/CommonErrorCode.java
+++ b/src/main/java/com/amp/global/common/CommonErrorCode.java
@@ -8,24 +8,30 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
     // 400 Bad Request
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다."),
-    TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "C002", "입력값의 타입이 일치하지 않습니다."),
-    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "C003", "필수 파라미터가 누락되었습니다."),
-    INVALID_JSON(HttpStatus.BAD_REQUEST, "C004", "JSON 파싱 중 오류가 발생했습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COM", "001", "잘못된 입력값입니다."),
+    TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "COM", "002", "입력값의 타입이 일치하지 않습니다."),
+    MISSING_PARAMETER(HttpStatus.BAD_REQUEST, "COM", "003", "필수 파라미터가 누락되었습니다."),
+    INVALID_JSON(HttpStatus.BAD_REQUEST, "COM", "004", "JSON 파싱 중 오류가 발생했습니다."),
 
     // 401 Unauthorized
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "C005", "로그인이 필요한 서비스입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COM", "001", "로그인이 필요한 서비스입니다."),
 
     // 403 Forbidden
-    FORBIDDEN(HttpStatus.FORBIDDEN, "C006", "해당 요청에 대한 권한이 없습니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "COM", "001", "해당 요청에 대한 권한이 없습니다."),
 
-    // 405 Method Not Allowed
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C007", "지원하지 않는 HTTP 메소드입니다."),
+    // 404 Not Found
+    NOT_FOUND(HttpStatus.NOT_FOUND, "COM", "001", "찾을 수 없는 리소스입니다."),
 
     // 500 Internal Server Error
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C008", "서버 내부 오류가 발생했습니다.");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COM", "001", "서버 내부 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
-    private final String code;
+    private final String domain;
+    private final String numbering;
     private final String msg;
+
+    @Override
+    public String getCode() {
+        return domain + "_" + httpStatus.value() + "_" + numbering;
+    }
 }


### PR DESCRIPTION
## 💭 Related Issue
close #26 

<br/>

## 💻 Key Changes
- [x] 기존 에러 응답 형식 수정

<br/>

## 💪🏻 To Reviewers
기존에는 Httpstatus 값, 도메인 앞글자 따서 넘버링, 에러 메세지의 구성으로 이루어져있었는데 에러 발생시 클라와 빠른 소통을 위해
**도메인 앞 세글자 + 상태값 + 넘버링** 으로 수정하였습니다.
<img width="675" height="162" alt="image" src="https://github.com/user-attachments/assets/5f2ccb4c-3047-4105-88e3-f43da5fa6c5b" />

사진과 같이 응답옵니다!
<br/>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 오류 코드 체계를 개선하여 더 명확한 오류 식별 가능
  * 일관된 오류 응답 형식으로 시스템 안정성 향상
  * 리소스 미발견 등 추가 오류 타입 지원

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->