### PR TITLE
[Fix/#94] SecurityConfig 분리

### DIFF
--- a/src/main/java/com/amp/global/config/SecurityConfig.java
+++ b/src/main/java/com/amp/global/config/SecurityConfig.java
@@ -20,12 +20,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import java.util.Arrays;
 
 @Slf4j
 @Configuration
@@ -41,9 +36,6 @@ public class SecurityConfig {
     private final OnboardingCheckFilter onboardingCheckFilter;
     private final ClientRegistrationRepository clientRegistrationRepository;
 
-    @Value("${app.cors.allowed-origins:http://localhost:3000,http://localhost:5173}")
-    private String allowedOrigins;
-
     @Value("${app.oauth2.failure-redirect-uri:http://localhost:3000/login}")
     private String failureRedirectUri;
 
@@ -53,8 +45,7 @@ public class SecurityConfig {
                 // CSRF 비활성화 (JWT 사용)
                 .csrf(csrf -> csrf.disable())
 
-                // CORS 설정
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .cors(cors -> cors.disable())
 
                 // 세션 관리 - STATELESS (JWT 사용)
                 .sessionManagement(session ->
@@ -154,22 +145,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList(allowedOrigins.split(",")));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("*"));
-        configuration.setAllowCredentials(true);
-        configuration.setMaxAge(3600L);
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
-    }
-
-    @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-
 }

--- a/src/main/java/com/amp/global/config/WebConfig.java
+++ b/src/main/java/com/amp/global/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.amp.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${app.cors.allowed-origins}")
+    private String allowedOrigins;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(allowedOrigins.split(","))
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(3600);
+    }
+}


### PR DESCRIPTION
## 💭 Related Issue
closed #94 

<br/>

## 💻 Key Changes
- [x] SecurityConfig와 WebConfig 파일을 분리했습니다.

<br/>

## 💪🏻 To Reviewers
리뷰스킵

<br/>

## 📎 ETC
기타

<br/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * CORS(Cross-Origin Resource Sharing) 구성이 보안 설정에서 애플리케이션 전역 설정으로 이동되었습니다. 허용된 출처, HTTP 메서드 및 헤더는 이제 설정 속성을 통해 중앙집중식으로 관리됩니다. 허용된 요청에 대한 최대 캐시 시간은 3600초로 설정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->