### PR TITLE
[Refactor/#129] Security에서 온보딩시 허용 URL 추가 

### DIFF
--- a/src/main/java/com/amp/global/security/OnboardingCheckFilter.java
+++ b/src/main/java/com/amp/global/security/OnboardingCheckFilter.java
@@ -26,8 +26,9 @@ public class OnboardingCheckFilter extends OncePerRequestFilter {
     private final UserRepository userRepository;
 
     private static final List<String> SKIP_PATHS = Arrays.asList(
-            "/api/auth/onboarding",
-            "/api/auth/login",
+            "/api/v1/auth/onboarding",
+            "/api/v1/auth/login",
+            "/api/*",
             "/oauth2",
             "/login",
             "/h2-console"


### PR DESCRIPTION
## 💭 Related Issue
#129 

<br/>

## 💻 Key Changes
Security에서 온보딩시 아직 회원가입되지 않은 객체들이 접근할 수 있는 Path들을 확대 했습니다.

<br/>

## 💪🏻 To Reviewers
빠르게 프론트와 작업을 위해서 merge하겠습니다.

<br/>

## 📎 ETC
기타

<br/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 온보딩 검사를 우회하는 경로를 확대하여 특정 API 엔드포인트와 V1 버전의 인증 관련 경로에서 검사 프로세스를 스킵하도록 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->