### PR TITLE
[Refactor/#203] 관람 예정 공연 중 최근 공연 조회 API 반환값 수정

### DIFF
--- a/src/main/java/com/amp/domain/wishList/controller/WishListController.java
+++ b/src/main/java/com/amp/domain/wishList/controller/WishListController.java
@@ -38,6 +38,12 @@ public class WishListController {
     public ResponseEntity<BaseResponse<RecentWishListResponse>> getRecentFestival(
             @AuthenticationPrincipal CustomUserPrincipal principal) {
 
+        if (principal == null) {
+            return ResponseEntity
+                    .status(SuccessStatus.USER_FESTIVAL_RECENT_UNAUTHENTICATED.getHttpStatus())
+                    .body(BaseResponse.of(SuccessStatus.USER_FESTIVAL_RECENT_UNAUTHENTICATED, null));
+        }
+
         Long userId = principal.getUserId();
         RecentWishListResponse response = wishListService.getRecentFestival(userId).orElse(null);
 

--- a/src/main/java/com/amp/global/common/SuccessStatus.java
+++ b/src/main/java/com/amp/global/common/SuccessStatus.java
@@ -16,15 +16,16 @@ public enum SuccessStatus implements SuccessCode {
 
     // FESTIVAL
     FESTIVAL_CREATE_SUCCESS(HttpStatus.CREATED, "FES", "001", "공연 등록이 완료되었습니다."),
-
-    // UserFestival
-    USER_FESTIVAL_RECENT_FOUND(HttpStatus.OK, "UFE", "001", "관람 예정 최근에 보는 공연 정보가 조회되었습니다."),
-    USER_FESTIVAL_RECENT_NOT_FOUND(HttpStatus.OK, "UFE", "002", "관람 예정 정보가 없습니다."),
     GET_FESTIVAL_DETAIL_INFO(HttpStatus.OK, "FES", "002", "공연 상세 정보가 조회되었습니다."),
     FESTIVAL_UPDATE_SUCCESS(HttpStatus.OK, "FES", "003", "공연 정보 수정이 완료되었습니다."),
     FESTIVAL_DELETE_SUCCESS(HttpStatus.OK, "FES", "004", "공연 삭제가 완료되었습니다."),
     FESTIVAL_LIST_EMPTY(HttpStatus.OK, "FES", "005", "등록된 공연이 없습니다."),
     FESTIVAL_LIST_FOUND(HttpStatus.OK, "FES", "006", "전체 공연 정보가 조회되었습니다."),
+
+    // UserFestival
+    USER_FESTIVAL_RECENT_FOUND(HttpStatus.OK, "UFE", "001", "관람 예정 최근에 보는 공연 정보가 조회되었습니다."),
+    USER_FESTIVAL_RECENT_NOT_FOUND(HttpStatus.OK, "UFE", "002", "관람 예정 정보가 없습니다."),
+    USER_FESTIVAL_RECENT_UNAUTHENTICATED(HttpStatus.OK, "UFE", "003", "비로그인 사용자로 관람 예정 공연이 없습니다."),
 
     // ORGANIZER
     GET_MY_ALL_FESTIVALS(HttpStatus.OK, "ORG", "001", "나의 진행한 모든 공연 조회가 완료되었습니다."),

--- a/src/main/java/com/amp/global/config/SecurityConfig.java
+++ b/src/main/java/com/amp/global/config/SecurityConfig.java
@@ -84,7 +84,8 @@ public class SecurityConfig {
                                 "/api/v1/common/festivals/*/notices",
                                 "/api/v1/common/festivals/*/congestion",
                                 "/api/v1/users/festivals",
-                                "/api/v1/users/nickname"
+                                "/api/v1/users/nickname",
+                                "/api/v1/users/me/festivals/recent"
                         ).permitAll()
 
                         .requestMatchers(


### PR DESCRIPTION
## 💭 Related Issue
closed #203 

<br/>

## 💻 Key Changes
### 1. 관람 예정 공연 중 최근 공연 조회 API 반환값 수정
기존에는 관람 예정 공연 API는 전부 로그인된 사용자만 사용할 수 있어서 비로그인 사용자의 경우 401이 떴습니다. 하지만 해당 API의 경우 홈 화면에서 호출되어 비로그인 사용자도 사용하기에 401 에러가 적합하지 않다고 판단하였습니다.
프론트측과의 논의로 비로그인 사용자는 null 값을 반환하기로 하였고, 로그인 사용자는 기존 응답대로 반환됩니다.


```
{   
     "status": 200,   
     "msg": "비로그인 사용자로 관람 예정 공연이 없습니다.",   
     "data": null 
}
```

- SecurityConfig: 구체적인 api 경로를 명시하여 추가하였습니다.
- SuccessStatus: 비로그인 유저의 관람예정 정보가 없는 경우와 로그인 유저의 관람 예정 정보가 없는 경우를 구분하기 위해 응답 코드를 추가하였습니다.



<br/>

## 💪🏻 To Reviewers
SuccessStatus 컨벤션에 대해 논의할 부분이 있습니다.
현재 도메인 값을 나타내는 영문 세글자가 모호하게 작성된 부분이 있는데 한 번 회의를 하고 수정하는 과정을 거치면 좋을 것 같습니다.

<br/>

## 📎 ETC

<br/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 비로그인 사용자도 최근 공연 정보 조회 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->